### PR TITLE
Add array expansion for property names

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Assorted JSON-related typescript utilities that I'm tired of copying from projec
 - [Overview](#overview)
   - [Type-Safe JSON](#type-safe-json)
   - [Templated JSON](#templated-json)
+    - [Array Property Expansion](#array-property-expansion)
   - [Conditional JSON](#conditional-json)
     - [Conditional Match Properties](#conditional-match-properties)
     - [Defined Condition Properties](#defined-condition-properties)
@@ -65,6 +66,39 @@ interface JsonArray extends Array<JsonValue> { }
     //    litealValue: 'literal',
     // }
 ```
+
+#### Array Property Expansion
+In a templated JSON object, a key of the form ```"[[name]]=value1,value2,...``` is expanded to multiple properties, one property per item in the comma-separated list that follows the equals sign.  Each property has the name of the corresponding list value, and the value of the property is resolved as templated JSON using a context with the property named inside of the square brackets assigned the list value being resolved.  For example:
+
+```ts
+    // with context:
+    const context = {
+        properties: ['first', 'second', 'third'],
+    };
+
+    // templated conversion of:
+    const src = {
+        '[[prop]]={{properties}}': {
+            '{{prop}}Prop': '{{prop}} value',
+        },
+    };
+
+    // yields
+    const expected = {
+        first: {
+            firstProp: 'first value',
+        },
+        second: {
+            secondProp: 'second value',
+        },
+        third: {
+            thirdProp: 'third value',
+        },
+    };
+```
+
+The converter options for templated JSON allow for an override of the function that derives the context for each of the children, so it is possible to write a custom derivation function which sets different or additional values based on the
+value passed in.
 
 ### Conditional JSON
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "@fgv/ts-json",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -38,12 +38,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "json5": {
@@ -393,12 +393,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "globals": {
@@ -461,12 +461,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ignore": {
@@ -484,9 +484,9 @@
       }
     },
     "@fgv/ts-utils": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@fgv/ts-utils/-/ts-utils-0.3.3.tgz",
-      "integrity": "sha512-zCED7Pak3mQd6zVnvUmvzywaI2fob7X/vgRSc2368HI5N5YqTYu0gxJ3niRhGO3794gCpzCRyPx6qq2IPl9YPg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@fgv/ts-utils/-/ts-utils-0.3.5.tgz",
+      "integrity": "sha512-hPCeM5lXGdHzIrpOKgrF/H9EAPgqrMvE6xt2NonY9z/AEQVaFMmEYXFuYTd7/dfpwA9c1osP7YZ7XQjoL9H49A==",
       "requires": {
         "csv-parse": "^4.12.0",
         "luxon": "^1.25.0",
@@ -533,103 +533,503 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
-      "integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.5.0.tgz",
+      "integrity": "sha512-oh59scth4yf8XUgMJb8ruY7BHm0X5JZDNgGGsVnlOt2XQuq9s2NMllIrN4n70Yds+++bjrTGZ9EoOKraaPKPlg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^26.3.0",
-        "jest-util": "^26.3.0",
+        "jest-message-util": "^26.5.0",
+        "jest-util": "^26.5.0",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
+        "jest-message-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
+          "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        }
       }
     },
     "@jest/core": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
-      "integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.5.0.tgz",
+      "integrity": "sha512-hDtgfzYxnrQn54+0JlbqpXM4+bqDfK0ooMlNE4Nn3VBsB4RbmytAn4/kVVIcMa+aYwRr/fwzWuGJwBETVg1sDw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.3.0",
-        "@jest/reporters": "^26.4.1",
-        "@jest/test-result": "^26.3.0",
-        "@jest/transform": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/reporters": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/transform": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-changed-files": "^26.3.0",
-        "jest-config": "^26.4.2",
-        "jest-haste-map": "^26.3.0",
-        "jest-message-util": "^26.3.0",
+        "jest-changed-files": "^26.5.0",
+        "jest-config": "^26.5.0",
+        "jest-haste-map": "^26.5.0",
+        "jest-message-util": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.4.0",
-        "jest-resolve-dependencies": "^26.4.2",
-        "jest-runner": "^26.4.2",
-        "jest-runtime": "^26.4.2",
-        "jest-snapshot": "^26.4.2",
-        "jest-util": "^26.3.0",
-        "jest-validate": "^26.4.2",
-        "jest-watcher": "^26.3.0",
+        "jest-resolve": "^26.5.0",
+        "jest-resolve-dependencies": "^26.5.0",
+        "jest-runner": "^26.5.0",
+        "jest-runtime": "^26.5.0",
+        "jest-snapshot": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-validate": "^26.5.0",
+        "jest-watcher": "^26.5.0",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
+          "dev": true
+        },
+        "expect": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.0.tgz",
+          "integrity": "sha512-oIOy3mHWjnF5ZICuaui5kdtJZQ+D7XHWyUQDxk1WhIRCkcIYc24X23bOfikgCNU6i9wcSqLQhwPOqeRp09naxg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.5.0",
+            "jest-message-util": "^26.5.0",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
+        "jest-diff": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.0.tgz",
+          "integrity": "sha512-CmDMMPkVMxrrh0Dv/4M9kh1tsYsZnYTQMMTvIFpePBSk9wMVfcyfg30TCq+oR9AzGbw8vsI50Gk1HmlMMlhoJg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-haste-map": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
+          "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/graceful-fs": "^4.1.2",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-regex-util": "^26.0.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-worker": "^26.5.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.0.tgz",
+          "integrity": "sha512-QgbbxqFT8wiTi4o/7MWj2vHlcmMjACG8vnJ9pJ7svVDmkzEnTUGdHXWLKB1aZhbnyXetMNRF+TSMcDS9aGfuzA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
+          "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-resolve": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.0.tgz",
+          "integrity": "sha512-c34L8Lrw4fFzRiCLzwePziKRfHitjsAnY15ID0e9Se4ISikmZ5T9icLEFAGHnfaxfb+9r8EKdrbg89gjRdrQvw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "chalk": "^4.0.0",
+            "escalade": "^3.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.5.0",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-snapshot": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.0.tgz",
+          "integrity": "sha512-WTNJef67o7cCvwAe5foVCNqG3MzIW/CyU4FZvMrhBPZsJeXwfBY7kfOlydZigxtcytnvmNE2pqznOfD5EcQgrQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/babel__traverse": "^7.0.4",
+            "@types/prettier": "^2.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^26.5.0",
+            "graceful-fs": "^4.2.4",
+            "jest-diff": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "jest-haste-map": "^26.5.0",
+            "jest-matcher-utils": "^26.5.0",
+            "jest-message-util": "^26.5.0",
+            "jest-resolve": "^26.5.0",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^26.5.0",
+            "semver": "^7.3.2"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
       }
     },
     "@jest/environment": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
-      "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.0.tgz",
+      "integrity": "sha512-0F3G9EyZU2NAP0/c/5EqVx4DmldQtRxj0gMl3p3ciSCdyMiCyDmpdE7O0mKTSiFDyl1kU4TfgEVf0r0vMkmYcw==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/fake-timers": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
-        "jest-mock": "^26.3.0"
+        "jest-mock": "^26.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/fake-timers": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
-      "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.5.0.tgz",
+      "integrity": "sha512-sQK6xUembaZ0qLnZpSjJJuJiKvyrjCJhaYjbmatFpj5+cM8h2D7YEkeEBC26BMzvF1O3tNM9OL7roqyBmom0KA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "@sinonjs/fake-timers": "^6.0.1",
         "@types/node": "*",
-        "jest-message-util": "^26.3.0",
-        "jest-mock": "^26.3.0",
-        "jest-util": "^26.3.0"
+        "jest-message-util": "^26.5.0",
+        "jest-mock": "^26.5.0",
+        "jest-util": "^26.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
+        "jest-message-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
+          "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        }
       }
     },
     "@jest/globals": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
-      "integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.5.0.tgz",
+      "integrity": "sha512-TCKx3XWR9h/yyhQbz0C1sXkK2e8WJOnkP40T9bewNpf2Ahr1UEyKXnCoQO0JCpXFkWGTXBNo1QAgTQ3+LhXfcA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.3.0",
-        "@jest/types": "^26.3.0",
-        "expect": "^26.4.2"
+        "@jest/environment": "^26.5.0",
+        "@jest/types": "^26.5.0",
+        "expect": "^26.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
+          "dev": true
+        },
+        "expect": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.0.tgz",
+          "integrity": "sha512-oIOy3mHWjnF5ZICuaui5kdtJZQ+D7XHWyUQDxk1WhIRCkcIYc24X23bOfikgCNU6i9wcSqLQhwPOqeRp09naxg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.5.0",
+            "jest-message-util": "^26.5.0",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
+        "jest-diff": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.0.tgz",
+          "integrity": "sha512-CmDMMPkVMxrrh0Dv/4M9kh1tsYsZnYTQMMTvIFpePBSk9wMVfcyfg30TCq+oR9AzGbw8vsI50Gk1HmlMMlhoJg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.0.tgz",
+          "integrity": "sha512-QgbbxqFT8wiTi4o/7MWj2vHlcmMjACG8vnJ9pJ7svVDmkzEnTUGdHXWLKB1aZhbnyXetMNRF+TSMcDS9aGfuzA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
+          "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "pretty-format": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
       }
     },
     "@jest/reporters": {
-      "version": "26.4.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
-      "integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.5.0.tgz",
+      "integrity": "sha512-lUl5bbTHflDO9dQa85ZTHasPBVsyC48t9sg/VN2wC3OJryclFNqN4Xfo2FgnNl/pzCnzO2MVgMyIij5aNkod2w==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^26.3.0",
-        "@jest/test-result": "^26.3.0",
-        "@jest/transform": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/transform": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
@@ -640,10 +1040,10 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.0.2",
-        "jest-haste-map": "^26.3.0",
-        "jest-resolve": "^26.4.0",
-        "jest-util": "^26.3.0",
-        "jest-worker": "^26.3.0",
+        "jest-haste-map": "^26.5.0",
+        "jest-resolve": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-worker": "^26.5.0",
         "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
@@ -652,6 +1052,92 @@
         "v8-to-istanbul": "^5.0.1"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-haste-map": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
+          "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/graceful-fs": "^4.1.2",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-regex-util": "^26.0.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-worker": "^26.5.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-resolve": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.0.tgz",
+          "integrity": "sha512-c34L8Lrw4fFzRiCLzwePziKRfHitjsAnY15ID0e9Se4ISikmZ5T9icLEFAGHnfaxfb+9r8EKdrbg89gjRdrQvw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "chalk": "^4.0.0",
+            "escalade": "^3.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.5.0",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -661,9 +1147,9 @@
       }
     },
     "@jest/source-map": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
-      "integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
+      "integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0",
@@ -680,46 +1166,133 @@
       }
     },
     "@jest/test-result": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
-      "integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.5.0.tgz",
+      "integrity": "sha512-CaVXxDQi31LPOsz5/+iajNHQlA1Je/jQ8uYH/lCa6Y/UrkO+sDHeEH3x/inbx06PctVDnTwIlCcBvNNbC4FCvQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "@jest/test-sequencer": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
-      "integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.5.0.tgz",
+      "integrity": "sha512-23oofRXqPEy37HyHWIYf7lzzOqtGBkai5erZiL6RgxlyXE7a0lCihf6b5DfAvcD3yUtbXmh3EzpjJDVH57zQrg==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.3.0",
+        "@jest/test-result": "^26.5.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.3.0",
-        "jest-runner": "^26.4.2",
-        "jest-runtime": "^26.4.2"
+        "jest-haste-map": "^26.5.0",
+        "jest-runner": "^26.5.0",
+        "jest-runtime": "^26.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-haste-map": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
+          "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/graceful-fs": "^4.1.2",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-regex-util": "^26.0.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-worker": "^26.5.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        }
       }
     },
     "@jest/transform": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
-      "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.0.tgz",
+      "integrity": "sha512-Kt4WciOruTyTkJ2DZ+xtZiejRj3v22BrXCYZoGRbI0N6Q6tt2HdsWrrEtn6nlK24QWKC389xKkVk4Xr2gWBZQA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "babel-plugin-istanbul": "^6.0.0",
         "chalk": "^4.0.0",
         "convert-source-map": "^1.4.0",
         "fast-json-stable-stringify": "^2.0.0",
         "graceful-fs": "^4.2.4",
-        "jest-haste-map": "^26.3.0",
+        "jest-haste-map": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-util": "^26.3.0",
+        "jest-util": "^26.5.0",
         "micromatch": "^4.0.2",
         "pirates": "^4.0.1",
         "slash": "^3.0.0",
@@ -727,6 +1300,76 @@
         "write-file-atomic": "^3.0.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-haste-map": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
+          "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/graceful-fs": "^4.1.2",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-regex-util": "^26.0.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-worker": "^26.5.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -793,9 +1436,9 @@
       }
     },
     "@types/babel__core": {
-      "version": "7.1.9",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.9.tgz",
-      "integrity": "sha512-sY2RsIJ5rpER1u3/aQ8OFSI7qGIy8o1NEEbgb2UaJcvOtXOMpd39ko723NBpjQFg9SIX7TXtjejZVGeIMLhoOw==",
+      "version": "7.1.10",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.10.tgz",
+      "integrity": "sha512-x8OM8XzITIMyiwl5Vmo2B1cR1S1Ipkyv4mdlbJjMa1lmuKvKY9FrBbEANIaMlnWn5Rf7uO+rC/VgYabNkE17Hw==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -806,18 +1449,18 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+      "integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }
     },
     "@types/babel__template": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-      "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.3.tgz",
+      "integrity": "sha512-uCoznIPDmnickEi6D0v11SBpW0OuVqHJCa7syXqQHy5uktSCreIlt0iglsCnmvz8yCb38hGcWeseA8cWJSwv5Q==",
       "dev": true,
       "requires": {
         "@babel/parser": "^7.1.0",
@@ -825,9 +1468,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.14.tgz",
-      "integrity": "sha512-8w9szzKs14ZtBVuP6Wn7nMLRJ0D6dfB0VEBEyRgxrZ/Ln49aNMykrghM2FaNn4FJRzNppCSa0Rv9pBRM5Xc3wg==",
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+      "integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -971,9 +1614,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.11.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
-      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==",
+      "version": "14.11.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.4.tgz",
+      "integrity": "sha512-KmoLCUeW2cWKkEOQ0gQcECuqOc0g7B7zcmRPQNMT4ntNm0luKv3BTLcqIyWpTxkhLDzLTdMus11j/6DROaZdPw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -1010,13 +1653,13 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.2.0.tgz",
-      "integrity": "sha512-zBNRkzvLSwo6y5TG0DVcmshZIYBHKtmzD4N+LYnfTFpzc4bc79o8jNRSb728WV7A4Cegbs+MV5IRAj8BKBgOVQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.4.0.tgz",
+      "integrity": "sha512-RVt5wU9H/2H+N/ZrCasTXdGbUTkbf7Hfi9eLiA8vPQkzUJ/bLDCC3CsoZioPrNcnoyN8r0gT153dC++A4hKBQQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.2.0",
-        "@typescript-eslint/scope-manager": "4.2.0",
+        "@typescript-eslint/experimental-utils": "4.4.0",
+        "@typescript-eslint/scope-manager": "4.4.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -1042,28 +1685,28 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.2.0.tgz",
-      "integrity": "sha512-5BBj6BjgHEndBaQQpUVzRIPERz03LBc0MCQkHwUaH044FJFL08SwWv/sQftk7gf0ShZ2xZysz0LTwCwNt4Xu3w==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.4.0.tgz",
+      "integrity": "sha512-01+OtK/oWeSJTjQcyzDztfLF1YjvKpLFo+JZmurK/qjSRcyObpIecJ4rckDoRCSh5Etw+jKfdSzVEHevh9gJ1w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.2.0",
-        "@typescript-eslint/types": "4.2.0",
-        "@typescript-eslint/typescript-estree": "4.2.0",
+        "@typescript-eslint/scope-manager": "4.4.0",
+        "@typescript-eslint/types": "4.4.0",
+        "@typescript-eslint/typescript-estree": "4.4.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.2.0.tgz",
-      "integrity": "sha512-54jJ6MwkOtowpE48C0QJF9iTz2/NZxfKVJzv1ha5imigzHbNSLN9yvbxFFH1KdlRPQrlR8qxqyOvLHHxd397VA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.4.0.tgz",
+      "integrity": "sha512-yc14iEItCxoGb7W4Nx30FlTyGpU9r+j+n1LUK/exlq2eJeFxczrz/xFRZUk2f6yzWfK+pr1DOTyQnmDkcC4TnA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.2.0",
-        "@typescript-eslint/types": "4.2.0",
-        "@typescript-eslint/typescript-estree": "4.2.0",
+        "@typescript-eslint/scope-manager": "4.4.0",
+        "@typescript-eslint/types": "4.4.0",
+        "@typescript-eslint/typescript-estree": "4.4.0",
         "debug": "^4.1.1"
       },
       "dependencies": {
@@ -1085,29 +1728,29 @@
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.2.0.tgz",
-      "integrity": "sha512-Tb402cxxObSxWIVT+PnBp5ruT2V/36yj6gG4C9AjkgRlZpxrLAzWDk3neen6ToMBGeGdxtnfFLoJRUecGz9mYQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.4.0.tgz",
+      "integrity": "sha512-r2FIeeU1lmW4K3CxgOAt8djI5c6Q/5ULAgdVo9AF3hPMpu0B14WznBAtxrmB/qFVbVIB6fSx2a+EVXuhSVMEyA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.2.0",
-        "@typescript-eslint/visitor-keys": "4.2.0"
+        "@typescript-eslint/types": "4.4.0",
+        "@typescript-eslint/visitor-keys": "4.4.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.2.0.tgz",
-      "integrity": "sha512-xkv5nIsxfI/Di9eVwN+G9reWl7Me9R5jpzmZUch58uQ7g0/hHVuGUbbn4NcxcM5y/R4wuJIIEPKPDb5l4Fdmwg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.4.0.tgz",
+      "integrity": "sha512-nU0VUpzanFw3jjX+50OTQy6MehVvf8pkqFcURPAE06xFNFenMj1GPEI6IESvp7UOHAnq+n/brMirZdR+7rCrlA==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.2.0.tgz",
-      "integrity": "sha512-iWDLCB7z4MGkLipduF6EOotdHNtgxuNKnYD54nMS/oitFnsk4S3S/TE/UYXQTra550lHtlv9eGmp+dvN9pUDtA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.4.0.tgz",
+      "integrity": "sha512-Fh85feshKXwki4nZ1uhCJHmqKJqCMba+8ZicQIhNi5d5jSQFteWiGeF96DTjO8br7fn+prTP+t3Cz/a/3yOKqw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.2.0",
-        "@typescript-eslint/visitor-keys": "4.2.0",
+        "@typescript-eslint/types": "4.4.0",
+        "@typescript-eslint/visitor-keys": "4.4.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
@@ -1134,12 +1777,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-WIf4BNOlFOH2W+YqGWa6YKLcK/EB3gEj2apCrqLw6mme1RzBy0jtJ9ewJgnrZDB640zfnv8L+/gwGH5sYp/rGw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.4.0.tgz",
+      "integrity": "sha512-oBWeroUZCVsHLiWRdcTXJB7s1nB3taFY8WGvS23tiAlT6jXVvsdAV4rs581bgdEjOhn43q6ro7NkOiLKu6kFqA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.2.0",
+        "@typescript-eslint/types": "4.4.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -1150,9 +1793,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true
     },
     "acorn-globals": {
@@ -1178,9 +1821,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -1356,19 +1999,34 @@
       "dev": true
     },
     "babel-jest": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
-      "integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.5.0.tgz",
+      "integrity": "sha512-Cy16ZJrds81C+JASaOIGNlpCeqW3PTOq36owv+Zzwde5NiWz+zNduwxUNF57vxc/3SnIWo8HHqTczhN8GLoXTw==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/transform": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/babel__core": "^7.1.7",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^26.3.0",
+        "babel-preset-jest": "^26.5.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "babel-plugin-istanbul": {
@@ -1385,9 +2043,9 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
-      "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
+      "integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.3.3",
@@ -1397,9 +2055,9 @@
       }
     },
     "babel-preset-current-node-syntax": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
-      "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+      "integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -1416,12 +2074,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
-      "integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
+      "integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "^26.2.0",
+        "babel-plugin-jest-hoist": "^26.5.0",
         "babel-preset-current-node-syntax": "^0.1.3"
       }
     },
@@ -1634,14 +2292,14 @@
       }
     },
     "cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.1.tgz",
+      "integrity": "sha512-rcvHOWyGyid6I1WjT/3NatKj2kDt9OdSHSXpyLXaMWFbKpGACNW8pRhhdPUq9MWUOdwn8Rz9AVETjF4105rZZQ==",
       "dev": true,
       "requires": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
+        "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -1832,16 +2490,10 @@
         "ms": "2.0.0"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
     "decimal.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
       "dev": true
     },
     "decode-uri-component": {
@@ -2021,20 +2673,20 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+      "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
       }
@@ -2049,6 +2701,12 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig==",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2118,9 +2776,9 @@
       }
     },
     "eslint": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.9.0.tgz",
-      "integrity": "sha512-V6QyhX21+uXp4T+3nrNfI3hQNBDa/P8ga7LoQOenwrlEFXrEnUEE+ok1dMtaS3b6rmLXhT1TkTIsG75HMLbknA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.10.0.tgz",
+      "integrity": "sha512-BDVffmqWl7JJXqCjAK6lWtcQThZB/aP1HXSH1JKwGwv0LQEdvpR7qzNrUT487RM39B5goWuboFad5ovMBmD8yA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -2131,7 +2789,7 @@
         "debug": "^4.0.1",
         "doctrine": "^3.0.0",
         "enquirer": "^2.3.5",
-        "eslint-scope": "^5.1.0",
+        "eslint-scope": "^5.1.1",
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^1.3.0",
         "espree": "^7.3.0",
@@ -2174,12 +2832,12 @@
           }
         },
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "eslint-visitor-keys": {
@@ -2269,9 +2927,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
-      "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -2279,7 +2937,7 @@
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.3",
+        "eslint-import-resolver-node": "^0.3.4",
         "eslint-module-utils": "^2.6.0",
         "has": "^1.0.3",
         "minimatch": "^3.0.4",
@@ -3190,9 +3848,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.1.tgz",
-      "integrity": "sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
       "dev": true
     },
     "is-ci": {
@@ -3441,12 +4099,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -3474,50 +4132,90 @@
       }
     },
     "jest": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
-      "integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.5.0.tgz",
+      "integrity": "sha512-yW1QTkdpxVWTV2M5cOwVdEww8dRGqL5bb7FOG3YQoMtf7oReCEawmU0+tOKkZUSfcOymbXmCfdBQLzuwOLCx0w==",
       "dev": true,
       "requires": {
-        "@jest/core": "^26.4.2",
+        "@jest/core": "^26.5.0",
         "import-local": "^3.0.2",
-        "jest-cli": "^26.4.2"
+        "jest-cli": "^26.5.0"
       },
       "dependencies": {
-        "jest-cli": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
-          "integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
           "dev": true,
           "requires": {
-            "@jest/core": "^26.4.2",
-            "@jest/test-result": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-cli": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.5.0.tgz",
+          "integrity": "sha512-bI0h6GQGbyN0SSZu3nPilwrkrZ8dBC93erwTiEoJ+kGjtNuXsB183hTZ0HCiHLzf88oE0SQB1hYp8RgyytH+Bg==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^26.5.0",
+            "@jest/test-result": "^26.5.0",
+            "@jest/types": "^26.5.0",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.2",
+            "jest-config": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-validate": "^26.5.0",
             "prompts": "^2.0.1",
-            "yargs": "^15.3.1"
+            "yargs": "^16.0.3"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
           }
         }
       }
     },
     "jest-changed-files": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
-      "integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.5.0.tgz",
+      "integrity": "sha512-RAHoXqxa7gO1rZz88qpsLpzJ2mQU12UaFWadacKHuMbBZwFK+yl0j9YoD9Y/wBpv1ILG2SdCuxFHggX+9VU7qA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "execa": "^4.0.0",
         "throat": "^5.0.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "cross-spawn": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3603,29 +4301,86 @@
       }
     },
     "jest-config": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
-      "integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.5.0.tgz",
+      "integrity": "sha512-OM6eXIEmQXAuonCk8aNPMRjPFcKWa3IIoSlq5BPgIflmQBzM/COcI7XsWSIEPWPa9WcYTJBWj8kNqEYjczmIFw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.1.0",
-        "@jest/test-sequencer": "^26.4.2",
-        "@jest/types": "^26.3.0",
-        "babel-jest": "^26.3.0",
+        "@jest/test-sequencer": "^26.5.0",
+        "@jest/types": "^26.5.0",
+        "babel-jest": "^26.5.0",
         "chalk": "^4.0.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.1",
         "graceful-fs": "^4.2.4",
-        "jest-environment-jsdom": "^26.3.0",
-        "jest-environment-node": "^26.3.0",
+        "jest-environment-jsdom": "^26.5.0",
+        "jest-environment-node": "^26.5.0",
         "jest-get-type": "^26.3.0",
-        "jest-jasmine2": "^26.4.2",
+        "jest-jasmine2": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.4.0",
-        "jest-util": "^26.3.0",
-        "jest-validate": "^26.4.2",
+        "jest-resolve": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-validate": "^26.5.0",
         "micromatch": "^4.0.2",
-        "pretty-format": "^26.4.2"
+        "pretty-format": "^26.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-resolve": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.0.tgz",
+          "integrity": "sha512-c34L8Lrw4fFzRiCLzwePziKRfHitjsAnY15ID0e9Se4ISikmZ5T9icLEFAGHnfaxfb+9r8EKdrbg89gjRdrQvw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "chalk": "^4.0.0",
+            "escalade": "^3.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.5.0",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "pretty-format": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
       }
     },
     "jest-diff": {
@@ -3650,45 +4405,144 @@
       }
     },
     "jest-each": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
-      "integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.5.0.tgz",
+      "integrity": "sha512-+oO3ykDgypHSyyK2xOsh8XDUwMtg3HoJ4wMNFNHxhcACFbUgaCOfLy+eTCn5pIKhtigU3BmkYt7k3MtTb5pJOQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
-        "jest-util": "^26.3.0",
-        "pretty-format": "^26.4.2"
+        "jest-util": "^26.5.0",
+        "pretty-format": "^26.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "pretty-format": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
       }
     },
     "jest-environment-jsdom": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
-      "integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.5.0.tgz",
+      "integrity": "sha512-Xuqh3bx8egymaJR566ECkiztIIVOIWWPGIxo++ziWyCOqQChUguRCH1hRXBbfINPbb/SRFe7GCD+SunaUgTmCw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.3.0",
-        "@jest/fake-timers": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/fake-timers": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
-        "jest-mock": "^26.3.0",
-        "jest-util": "^26.3.0",
-        "jsdom": "^16.2.2"
+        "jest-mock": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jsdom": "^16.4.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        }
       }
     },
     "jest-environment-node": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
-      "integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.5.0.tgz",
+      "integrity": "sha512-LaYl/ek5mb1VDP1/+jMH2N1Ec4fFUhSYmc8EZqigBgMov/2US8U5l7D3IlOf78e+wARUxPxUpTcybVVzAOu3jg==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.3.0",
-        "@jest/fake-timers": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/fake-timers": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
-        "jest-mock": "^26.3.0",
-        "jest-util": "^26.3.0"
+        "jest-mock": "^26.5.0",
+        "jest-util": "^26.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        }
       }
     },
     "jest-extended": {
@@ -4102,39 +4956,256 @@
       }
     },
     "jest-jasmine2": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
-      "integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.5.0.tgz",
+      "integrity": "sha512-NOA6PLORHTRTROOp5VysKCUVpFAjMMXUS1Xw7FvTMeYK5Ewx4rpxhFqiJ7JT4pENap9g9OuXo4cWR/MwCDTEeQ==",
       "dev": true,
       "requires": {
         "@babel/traverse": "^7.1.0",
-        "@jest/environment": "^26.3.0",
-        "@jest/source-map": "^26.3.0",
-        "@jest/test-result": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/source-map": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "expect": "^26.4.2",
+        "expect": "^26.5.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^26.4.2",
-        "jest-matcher-utils": "^26.4.2",
-        "jest-message-util": "^26.3.0",
-        "jest-runtime": "^26.4.2",
-        "jest-snapshot": "^26.4.2",
-        "jest-util": "^26.3.0",
-        "pretty-format": "^26.4.2",
+        "jest-each": "^26.5.0",
+        "jest-matcher-utils": "^26.5.0",
+        "jest-message-util": "^26.5.0",
+        "jest-runtime": "^26.5.0",
+        "jest-snapshot": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "pretty-format": "^26.5.0",
         "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
+          "dev": true
+        },
+        "expect": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.0.tgz",
+          "integrity": "sha512-oIOy3mHWjnF5ZICuaui5kdtJZQ+D7XHWyUQDxk1WhIRCkcIYc24X23bOfikgCNU6i9wcSqLQhwPOqeRp09naxg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.5.0",
+            "jest-message-util": "^26.5.0",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
+        "jest-diff": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.0.tgz",
+          "integrity": "sha512-CmDMMPkVMxrrh0Dv/4M9kh1tsYsZnYTQMMTvIFpePBSk9wMVfcyfg30TCq+oR9AzGbw8vsI50Gk1HmlMMlhoJg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-haste-map": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
+          "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/graceful-fs": "^4.1.2",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-regex-util": "^26.0.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-worker": "^26.5.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.0.tgz",
+          "integrity": "sha512-QgbbxqFT8wiTi4o/7MWj2vHlcmMjACG8vnJ9pJ7svVDmkzEnTUGdHXWLKB1aZhbnyXetMNRF+TSMcDS9aGfuzA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
+          "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-resolve": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.0.tgz",
+          "integrity": "sha512-c34L8Lrw4fFzRiCLzwePziKRfHitjsAnY15ID0e9Se4ISikmZ5T9icLEFAGHnfaxfb+9r8EKdrbg89gjRdrQvw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "chalk": "^4.0.0",
+            "escalade": "^3.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.5.0",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-snapshot": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.0.tgz",
+          "integrity": "sha512-WTNJef67o7cCvwAe5foVCNqG3MzIW/CyU4FZvMrhBPZsJeXwfBY7kfOlydZigxtcytnvmNE2pqznOfD5EcQgrQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/babel__traverse": "^7.0.4",
+            "@types/prettier": "^2.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^26.5.0",
+            "graceful-fs": "^4.2.4",
+            "jest-diff": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "jest-haste-map": "^26.5.0",
+            "jest-matcher-utils": "^26.5.0",
+            "jest-message-util": "^26.5.0",
+            "jest-resolve": "^26.5.0",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^26.5.0",
+            "semver": "^7.3.2"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
       }
     },
     "jest-leak-detector": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
-      "integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.5.0.tgz",
+      "integrity": "sha512-xZHvvTBbj3gUTtunLjPqP594BT6IUEpwA0AQpEQjVR8eBq8+R3qgU/KhoAcVcV0iqRM6pXtX7hKPZ5mLdynVSQ==",
       "dev": true,
       "requires": {
         "jest-get-type": "^26.3.0",
-        "pretty-format": "^26.4.2"
+        "pretty-format": "^26.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
       }
     },
     "jest-matcher-utils": {
@@ -4166,13 +5237,28 @@
       }
     },
     "jest-mock": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
-      "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.5.0.tgz",
+      "integrity": "sha512-8D1UmbnmjdkvTdYygTW26KZr95Aw0/3gEmMZQWkxIEAgEESVDbwDG8ygRlXSY214x9hFjtKezvfQUp36Ogl75w==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        }
       }
     },
     "jest-pnp-resolver": {
@@ -4204,78 +5290,566 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
-      "integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.5.0.tgz",
+      "integrity": "sha512-2e3YdS+dlTY00s0CEiMAa7Ap/mPfPaQV7d6Fzp7BQqHXO/2QhXn/yVTxnxR+dOIo/NOh7pqXZTQSn+2iWwPQQA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-snapshot": "^26.4.2"
+        "jest-snapshot": "^26.5.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
+          "dev": true
+        },
+        "expect": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.0.tgz",
+          "integrity": "sha512-oIOy3mHWjnF5ZICuaui5kdtJZQ+D7XHWyUQDxk1WhIRCkcIYc24X23bOfikgCNU6i9wcSqLQhwPOqeRp09naxg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.5.0",
+            "jest-message-util": "^26.5.0",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
+        "jest-diff": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.0.tgz",
+          "integrity": "sha512-CmDMMPkVMxrrh0Dv/4M9kh1tsYsZnYTQMMTvIFpePBSk9wMVfcyfg30TCq+oR9AzGbw8vsI50Gk1HmlMMlhoJg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-haste-map": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
+          "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/graceful-fs": "^4.1.2",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-regex-util": "^26.0.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-worker": "^26.5.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.0.tgz",
+          "integrity": "sha512-QgbbxqFT8wiTi4o/7MWj2vHlcmMjACG8vnJ9pJ7svVDmkzEnTUGdHXWLKB1aZhbnyXetMNRF+TSMcDS9aGfuzA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
+          "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-resolve": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.0.tgz",
+          "integrity": "sha512-c34L8Lrw4fFzRiCLzwePziKRfHitjsAnY15ID0e9Se4ISikmZ5T9icLEFAGHnfaxfb+9r8EKdrbg89gjRdrQvw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "chalk": "^4.0.0",
+            "escalade": "^3.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.5.0",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-snapshot": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.0.tgz",
+          "integrity": "sha512-WTNJef67o7cCvwAe5foVCNqG3MzIW/CyU4FZvMrhBPZsJeXwfBY7kfOlydZigxtcytnvmNE2pqznOfD5EcQgrQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/babel__traverse": "^7.0.4",
+            "@types/prettier": "^2.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^26.5.0",
+            "graceful-fs": "^4.2.4",
+            "jest-diff": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "jest-haste-map": "^26.5.0",
+            "jest-matcher-utils": "^26.5.0",
+            "jest-message-util": "^26.5.0",
+            "jest-resolve": "^26.5.0",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^26.5.0",
+            "semver": "^7.3.2"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        }
       }
     },
     "jest-runner": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
-      "integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+      "version": "26.5.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.5.1.tgz",
+      "integrity": "sha512-gFHXehvMZD8qwNzaIl2MDFFI99m4kKk06H2xh2u4IkC+tHYIJjE5J175l9cbL3RuU2slfS2m57KZgcPZfbTavQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.3.0",
-        "@jest/environment": "^26.3.0",
-        "@jest/test-result": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.7.1",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.4.2",
+        "jest-config": "^26.5.0",
         "jest-docblock": "^26.0.0",
-        "jest-haste-map": "^26.3.0",
-        "jest-leak-detector": "^26.4.2",
-        "jest-message-util": "^26.3.0",
-        "jest-resolve": "^26.4.0",
-        "jest-runtime": "^26.4.2",
-        "jest-util": "^26.3.0",
-        "jest-worker": "^26.3.0",
+        "jest-haste-map": "^26.5.0",
+        "jest-leak-detector": "^26.5.0",
+        "jest-message-util": "^26.5.0",
+        "jest-resolve": "^26.5.0",
+        "jest-runtime": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-worker": "^26.5.0",
         "source-map-support": "^0.5.6",
         "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
+        "jest-haste-map": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
+          "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/graceful-fs": "^4.1.2",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-regex-util": "^26.0.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-worker": "^26.5.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
+          "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-resolve": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.0.tgz",
+          "integrity": "sha512-c34L8Lrw4fFzRiCLzwePziKRfHitjsAnY15ID0e9Se4ISikmZ5T9icLEFAGHnfaxfb+9r8EKdrbg89gjRdrQvw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "chalk": "^4.0.0",
+            "escalade": "^3.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.5.0",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        }
       }
     },
     "jest-runtime": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
-      "integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.5.0.tgz",
+      "integrity": "sha512-CujjQWpMcsvSg0L+G3iEz6s7Th5IbiZseAaw/5R7Eb+IfnJdyPdjJ+EoXNV8n07snvW5nZTwV9QIfy6Vjris8A==",
       "dev": true,
       "requires": {
-        "@jest/console": "^26.3.0",
-        "@jest/environment": "^26.3.0",
-        "@jest/fake-timers": "^26.3.0",
-        "@jest/globals": "^26.4.2",
-        "@jest/source-map": "^26.3.0",
-        "@jest/test-result": "^26.3.0",
-        "@jest/transform": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/console": "^26.5.0",
+        "@jest/environment": "^26.5.0",
+        "@jest/fake-timers": "^26.5.0",
+        "@jest/globals": "^26.5.0",
+        "@jest/source-map": "^26.5.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/transform": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0",
         "collect-v8-coverage": "^1.0.0",
         "exit": "^0.1.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.4",
-        "jest-config": "^26.4.2",
-        "jest-haste-map": "^26.3.0",
-        "jest-message-util": "^26.3.0",
-        "jest-mock": "^26.3.0",
+        "jest-config": "^26.5.0",
+        "jest-haste-map": "^26.5.0",
+        "jest-message-util": "^26.5.0",
+        "jest-mock": "^26.5.0",
         "jest-regex-util": "^26.0.0",
-        "jest-resolve": "^26.4.0",
-        "jest-snapshot": "^26.4.2",
-        "jest-util": "^26.3.0",
-        "jest-validate": "^26.4.2",
+        "jest-resolve": "^26.5.0",
+        "jest-snapshot": "^26.5.0",
+        "jest-util": "^26.5.0",
+        "jest-validate": "^26.5.0",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0",
-        "yargs": "^15.3.1"
+        "yargs": "^16.0.3"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
+          "dev": true
+        },
+        "expect": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.0.tgz",
+          "integrity": "sha512-oIOy3mHWjnF5ZICuaui5kdtJZQ+D7XHWyUQDxk1WhIRCkcIYc24X23bOfikgCNU6i9wcSqLQhwPOqeRp09naxg==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.3.0",
+            "jest-matcher-utils": "^26.5.0",
+            "jest-message-util": "^26.5.0",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
+        "jest-diff": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.0.tgz",
+          "integrity": "sha512-CmDMMPkVMxrrh0Dv/4M9kh1tsYsZnYTQMMTvIFpePBSk9wMVfcyfg30TCq+oR9AzGbw8vsI50Gk1HmlMMlhoJg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-haste-map": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.0.tgz",
+          "integrity": "sha512-AjB1b53uqN7Cf2VN80x0wJajVZ+BMZC+G2CmWoG143faaMw7IhIcs3FTPuSgOx7cn3/bag7lgCq93naAvLO6EQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/graceful-fs": "^4.1.2",
+            "@types/node": "*",
+            "anymatch": "^3.0.3",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^2.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-regex-util": "^26.0.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.0",
+            "jest-worker": "^26.5.0",
+            "micromatch": "^4.0.2",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-matcher-utils": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.0.tgz",
+          "integrity": "sha512-QgbbxqFT8wiTi4o/7MWj2vHlcmMjACG8vnJ9pJ7svVDmkzEnTUGdHXWLKB1aZhbnyXetMNRF+TSMcDS9aGfuzA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "pretty-format": "^26.5.0"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.0.tgz",
+          "integrity": "sha512-UEOqdoTfX0AFyReL4q5N3CfDBWt+AtQzeszZuuGapU39vwEk90rTSBghCA/3FFEZzvGfH2LE4+0NaBI81Cu2Ow==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/stack-utils": "^2.0.0",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-resolve": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.0.tgz",
+          "integrity": "sha512-c34L8Lrw4fFzRiCLzwePziKRfHitjsAnY15ID0e9Se4ISikmZ5T9icLEFAGHnfaxfb+9r8EKdrbg89gjRdrQvw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "chalk": "^4.0.0",
+            "escalade": "^3.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-pnp-resolver": "^1.2.2",
+            "jest-util": "^26.5.0",
+            "resolve": "^1.17.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "jest-serializer": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-snapshot": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.0.tgz",
+          "integrity": "sha512-WTNJef67o7cCvwAe5foVCNqG3MzIW/CyU4FZvMrhBPZsJeXwfBY7kfOlydZigxtcytnvmNE2pqznOfD5EcQgrQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.0.0",
+            "@jest/types": "^26.5.0",
+            "@types/babel__traverse": "^7.0.4",
+            "@types/prettier": "^2.0.0",
+            "chalk": "^4.0.0",
+            "expect": "^26.5.0",
+            "graceful-fs": "^4.2.4",
+            "jest-diff": "^26.5.0",
+            "jest-get-type": "^26.3.0",
+            "jest-haste-map": "^26.5.0",
+            "jest-matcher-utils": "^26.5.0",
+            "jest-message-util": "^26.5.0",
+            "jest-resolve": "^26.5.0",
+            "natural-compare": "^1.4.0",
+            "pretty-format": "^26.5.0",
+            "semver": "^7.3.2"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        },
+        "jest-worker": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*",
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
         "strip-bom": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
@@ -4332,40 +5906,94 @@
       }
     },
     "jest-validate": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-      "integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.5.0.tgz",
+      "integrity": "sha512-603+CHUJD4nAZ+tY/A+wu3g8KEcBey2a7YOMU9W8e4u7mCezhaDasw20ITaZHoR2R2MZhThL6jApPSj0GvezrQ==",
       "dev": true,
       "requires": {
-        "@jest/types": "^26.3.0",
+        "@jest/types": "^26.5.0",
         "camelcase": "^6.0.0",
         "chalk": "^4.0.0",
         "jest-get-type": "^26.3.0",
         "leven": "^3.1.0",
-        "pretty-format": "^26.4.2"
+        "pretty-format": "^26.5.0"
       },
       "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
         "camelcase": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
           "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
           "dev": true
+        },
+        "pretty-format": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.0.tgz",
+          "integrity": "sha512-NcgRuuTutUJ9+Br4P19DFThpJYnYBiugfRmZEA6pXrUeG+IcMSmppb88rU+iPA+XAJcjTYlCb5Ed6miHg/Qqqw==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
         }
       }
     },
     "jest-watcher": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
-      "integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.5.0.tgz",
+      "integrity": "sha512-INLKhpc9QbO5zy2HkS1CJUncByrCLFDZQOY30d9ojiuGO02ofL1BygDRDRtFvT/oWSZ8Y0fbkrr1oXU2ay/MqA==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/test-result": "^26.5.0",
+        "@jest/types": "^26.5.0",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
-        "jest-util": "^26.3.0",
+        "jest-util": "^26.5.0",
         "string-length": "^4.0.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.0.tgz",
+          "integrity": "sha512-nH9DFLqaIhB+RVgjivemvMiFSWw/BKwbZGxBAMv8CCTvUyFoK8RwHhAlmlXIvMBrf5Z3YQ4p9cq3Qh9EDctGvA==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^3.0.0",
+            "@types/node": "*",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "jest-util": {
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.0.tgz",
+          "integrity": "sha512-CSQ0uzE7JdHDCQo3K8jlyWRIF2xNLdpu9nbjo8okGDanaNsF7WonhusFvjOg7QiWn1SThe7wFRh8Jx2ls1Gx4Q==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.5.0",
+            "@types/node": "*",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "micromatch": "^4.0.2"
+          }
+        }
       }
     },
     "jest-worker": {
@@ -4909,21 +6537,21 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
+            "is-callable": "^1.2.2",
             "is-negative-zero": "^2.0.0",
             "is-regex": "^1.1.1",
             "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -5392,12 +7020,6 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
     "resolve": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -5644,12 +7266,6 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
       "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "set-value": {
@@ -6245,9 +7861,9 @@
       }
     },
     "ts-jest": {
-      "version": "26.4.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.0.tgz",
-      "integrity": "sha512-ofBzoCqf6Nv/PoWb/ByV3VNKy2KJSikamOBxvR3E6eVdIw10GwAXoyvMWXXjZJK2s6S27ZE8fI+JBTnGaovl6Q==",
+      "version": "26.4.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.4.1.tgz",
+      "integrity": "sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==",
       "dev": true,
       "requires": {
         "@types/jest": "26.x",
@@ -6276,12 +7892,6 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "dev": true
-        },
-        "yargs-parser": {
-          "version": "20.2.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.0.tgz",
-          "integrity": "sha512-2agPoRFPoIcFzOIp6656gcvsg2ohtscpw2OINr/q46+Sq41xz2OYLqx5HRHabmFU1OARIPAYH5uteICE7mn/5A==",
           "dev": true
         }
       }
@@ -6451,9 +8061,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-      "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
       "dev": true,
       "optional": true
     },
@@ -6552,9 +8162,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-PcVnO6NiewhkmzV0qn7A+UZ9Xx4maNTI+O+TShmfE4pqjoCMwUMjkvoNhNHPTvgR7QH9Xt3R13iHuWy2sToFxQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.3.0.tgz",
+      "integrity": "sha512-BQRf/ej5Rp3+n7k0grQXZj9a1cHtsp4lqj01p59xBWFKdezR8sO37XnpafwNqiFac/v2Il12EIMjX/Y4VZtT8Q==",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -6571,12 +8181,6 @@
         "isexe": "^2.0.0"
       }
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -6584,9 +8188,9 @@
       "dev": true
     },
     "wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.0.0",
@@ -6665,28 +8269,24 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.2.tgz",
+      "integrity": "sha512-CkwaeZw6dQgqgPGeTWKMXCRmMcBgETFlTml1+ZOO+q7kGst8NREJ+eWwFNPVUQ4QGdAaklbqCZHH6Zuep1RjiA==",
       "dev": true
     },
     "yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.0.3.tgz",
+      "integrity": "sha512-6+nLw8xa9uK1BOEOykaiYAJVh6/CjxWXK/q9b5FpRgNslt8s22F2xMBqVIKgCRjNgGvGPBy8Vog7WN7yh4amtA==",
       "dev": true,
       "requires": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.0",
+        "escalade": "^3.0.2",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
         "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
+        "y18n": "^5.0.1",
+        "yargs-parser": "^20.0.0"
       },
       "dependencies": {
         "emoji-regex": {
@@ -6715,14 +8315,10 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-yYsjuSkjbLMBp16eaOt7/siKTjNVjMm3SoJnIg3sEh/JsvqVVDyjRKmaJV4cl+lNIgq6QEco2i3gDebJl7/vLA==",
+      "dev": true
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -28,23 +28,23 @@
     "@fgv/ts-utils-jest": "^0.3.1",
     "@types/jest": "^26.0.14",
     "@types/mustache": "^4.0.1",
-    "@types/node": "^14.11.2",
-    "@typescript-eslint/eslint-plugin": "^4.2.0",
-    "@typescript-eslint/parser": "^4.2.0",
-    "eslint": "^7.9.0",
+    "@types/node": "^14.11.4",
+    "@typescript-eslint/eslint-plugin": "^4.4.0",
+    "@typescript-eslint/parser": "^4.4.0",
+    "eslint": "^7.10.0",
     "eslint-config-standard": "^14.1.1",
-    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "jest": "^26.4.2",
+    "jest": "^26.5.0",
     "jest-extended": "^0.11.5",
     "rimraf": "^3.0.2",
-    "ts-jest": "^26.4.0",
+    "ts-jest": "^26.4.1",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@fgv/ts-utils": "^0.3.3"
+    "@fgv/ts-utils": "^0.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fgv/ts-json",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Typescript utilities for working with JSON",
   "main": "dist/index.js",
   "scripts": {

--- a/src/arrayProperty.ts
+++ b/src/arrayProperty.ts
@@ -72,7 +72,7 @@ export class ArrayPropertyConverter extends BaseConverter<JsonObject, TemplateCo
 
     protected constructor(
         parts: ArrayPropertyParts,
-        baseContext: TemplateContext,
+        baseContext: TemplateContext|undefined,
         childConverter: Converter<JsonValue, TemplateContext>,
         options: JsonConverterOptions,
     ) {
@@ -88,7 +88,7 @@ export class ArrayPropertyConverter extends BaseConverter<JsonObject, TemplateCo
 
     public static create(
         token: string,
-        context: TemplateContext,
+        context: TemplateContext|undefined,
         converter: Converter<JsonValue, TemplateContext>,
         options: JsonConverterOptions,
     ): DetailedResult<ArrayPropertyConverter, ArrayPropertyFailureReason> {
@@ -99,7 +99,7 @@ export class ArrayPropertyConverter extends BaseConverter<JsonObject, TemplateCo
 
     protected static _create(
         property: ArrayPropertyParts,
-        baseContext: TemplateContext,
+        baseContext: TemplateContext|undefined,
         converter: Converter<JsonValue, TemplateContext>,
         options: JsonConverterOptions
     ): DetailedResult<ArrayPropertyConverter, ArrayPropertyFailureReason> {

--- a/src/arrayProperty.ts
+++ b/src/arrayProperty.ts
@@ -92,8 +92,24 @@ export class ArrayPropertyConverter extends BaseConverter<JsonObject, TemplateCo
         converter: Converter<JsonValue, TemplateContext>,
         options: JsonConverterOptions,
     ): DetailedResult<ArrayPropertyConverter, ArrayPropertyFailureReason> {
+        if (options.useArrayTemplateNames === false) {
+            return failWithDetail(`${token}: array property names are disabled`, 'disabled');
+        }
+
         return ArrayPropertyParts.tryParse(token).onSuccess((p) => {
             return ArrayPropertyConverter._create(p, context, converter, options);
+        });
+    }
+
+    public static tryConvert(
+        token: string,
+        from: JsonValue,
+        context: TemplateContext|undefined,
+        converter: Converter<JsonValue, TemplateContext>,
+        options: JsonConverterOptions,
+    ): DetailedResult<JsonObject, ArrayPropertyFailureReason> {
+        return ArrayPropertyConverter.create(token, context, converter, options).onSuccess((ap) => {
+            return propagateWithDetail(ap.convert(from, context), 'error');
         });
     }
 

--- a/src/arrayProperty.ts
+++ b/src/arrayProperty.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2020 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import {
+    BaseConverter,
+    Converter,
+    DetailedResult,
+    Result,
+    allSucceed,
+    captureResult,
+    fail,
+    failWithDetail,
+    propagateWithDetail,
+    succeed,
+} from '@fgv/ts-utils';
+import { JsonObject, JsonValue, isJsonObject } from './common';
+
+export type ArrayContextCreator<TC=unknown> = (propName: string, propValue: string, context?: TC) => Result<TC>;
+export interface ArrayPropertyOptions<TC=unknown> {
+    allowArrayProperties: boolean;
+    contextCreator: ArrayContextCreator<TC>;
+}
+
+export function defaultObjectContextCreator(propName: string, propValue: string, context?: Record<string, unknown>): Result<Record<string, unknown>> {
+    if (!isJsonObject(context)) {
+        return fail(`Cannot mutate context "${JSON.stringify(context)}": not an object`);
+    }
+    const mutant = Object.create(context) as Record<string, unknown>;
+    mutant[propName] = propValue;
+    return succeed(mutant);
+}
+
+export function defaultArrayPropertyOptions<TC=unknown>(partial?: Partial<ArrayPropertyOptions<TC>>): ArrayPropertyOptions<TC> {
+    if (partial?.contextCreator !== undefined) {
+        return {
+            allowArrayProperties: partial?.allowArrayProperties ?? true,
+            contextCreator: partial.contextCreator,
+        };
+    }
+    return { allowArrayProperties: false, contextCreator: () => fail('context creator not implemented') };
+}
+
+export type ArrayPropertyFailureReason = 'error'|'disabled'|'notAnArray';
+export class ArrayProperty {
+    public readonly propertyVariable: string;
+    public readonly propertyValues: string[];
+
+    public constructor(propertyVariable: string, values: string[]) {
+        this.propertyVariable = propertyVariable;
+        this.propertyValues = values;
+    }
+
+    public static tryParse(token: string): DetailedResult<ArrayProperty, ArrayPropertyFailureReason> {
+        if (!token.startsWith('[[')) {
+            return failWithDetail(`Not an array property: ${token}`, 'notAnArray');
+        }
+
+        const parts = token.substring(2).split(']]=');
+        if (parts.length !== 2) {
+            return failWithDetail(`Malformed array property: ${token}`, 'error');
+        }
+
+        const valueParts = parts[1].split(',');
+        return propagateWithDetail(captureResult(() => new ArrayProperty(parts[0], valueParts)), 'error');
+    }
+}
+
+export class ArrayPropertyConverter<TC=unknown> extends BaseConverter<JsonObject, TC> {
+    protected readonly _property: ArrayProperty;
+    protected readonly _propertyConverter: Converter<JsonValue, TC>;
+    protected readonly _options: ArrayPropertyOptions<TC>;
+
+    protected constructor(
+        property: ArrayProperty,
+        baseContext: TC,
+        converter: Converter<JsonValue, TC>,
+        options: ArrayPropertyOptions<TC>
+    ) {
+        super((from, _self, context) => this._convert(from, context), baseContext);
+        this._property = property;
+        this._propertyConverter = converter;
+        this._options = options;
+    }
+
+    public static create<TC=undefined>(
+        token: string,
+        context: TC,
+        converter: Converter<JsonValue, TC>,
+        options?: Partial<ArrayPropertyOptions<TC>>,
+    ): DetailedResult<ArrayPropertyConverter<TC>, ArrayPropertyFailureReason> {
+        const effectiveOptions = defaultArrayPropertyOptions(options);
+        if (effectiveOptions.allowArrayProperties !== true) {
+            return failWithDetail(`${token}: Array properties disabled`, 'disabled');
+        }
+
+        return ArrayProperty.tryParse(token).onSuccess((p) => {
+            return ArrayPropertyConverter._create(p, context, converter, effectiveOptions);
+        });
+    }
+
+    protected static _create<TC=undefined>(
+        property: ArrayProperty,
+        baseContext: TC,
+        converter: Converter<JsonValue, TC>,
+        options: ArrayPropertyOptions<TC>
+    ): DetailedResult<ArrayPropertyConverter<TC>, ArrayPropertyFailureReason> {
+        return propagateWithDetail(
+            captureResult(() => new ArrayPropertyConverter(property, baseContext, converter, options)),
+            'error'
+        );
+    }
+
+    protected _convert(from: unknown, context?: TC): Result<JsonObject> {
+        const json: JsonObject = {};
+        context = this._context(context);
+
+        return allSucceed(this._property.propertyValues.map((pv) => {
+            return this._options.contextCreator(this._property.propertyVariable, pv, context).onSuccess((context) => {
+                return this._propertyConverter.convert(from, context).onSuccess((value) => {
+                    json[pv] = value;
+                    return succeed(value);
+                });
+            });
+        }), json);
+    }
+}

--- a/src/arrayProperty.ts
+++ b/src/arrayProperty.ts
@@ -32,7 +32,7 @@ import {
     succeed,
 } from '@fgv/ts-utils';
 import { JsonObject, JsonValue } from './common';
-import { TemplateContext, TemplateContextDeriver } from './templateContext';
+import { TemplateContext, TemplateContextDeriveFunction } from './templateContext';
 import { JsonConverterOptions } from './jsonConverter';
 
 export type ArrayContextCreator<TC=unknown> = (propName: string, propValue: string, context?: TC) => Result<TC>;
@@ -68,7 +68,7 @@ export class ArrayPropertyConverter extends BaseConverter<JsonObject, TemplateCo
     protected readonly _parts: ArrayPropertyParts;
     protected readonly _childConverter: Converter<JsonValue, TemplateContext>;
     protected readonly _options: JsonConverterOptions;
-    protected readonly _deriveContext: TemplateContextDeriver;
+    protected readonly _deriveContext: TemplateContextDeriveFunction;
 
     protected constructor(
         parts: ArrayPropertyParts,
@@ -80,10 +80,10 @@ export class ArrayPropertyConverter extends BaseConverter<JsonObject, TemplateCo
         this._parts = parts;
         this._childConverter = childConverter;
         this._options = options;
-        if (options.contextDeriver === undefined) {
+        if (options.deriveContext === undefined) {
             throw new Error(`${parts.token}: Cannot expand - no context mutation function`);
         }
-        this._deriveContext = options.contextDeriver;
+        this._deriveContext = options.deriveContext;
     }
 
     public static create(

--- a/src/conditionalJson.ts
+++ b/src/conditionalJson.ts
@@ -198,14 +198,18 @@ export class ConditionalJson extends BaseConverter<JsonValue> {
             // istanbul ignore else
             if (src.hasOwnProperty(prop)) {
                 let resolvedProp = prop;
+
                 if (this._options.useNameTemplates && this._isTemplateString(prop)) {
                     // resolve any templates in the property name
                     const renderResult = this._render(prop);
-                    if (renderResult.isSuccess()) {
+                    if (renderResult.isSuccess() && (renderResult.value.length > 0)) {
                         resolvedProp = renderResult.value;
                     }
-                    else if (this._options.onMalformedCondition === 'error') {
-                        return fail(`${prop}: ${renderResult.message}`);
+                    else if (this._options.onInvalidPropertyName === 'error') {
+                        if (renderResult.isFailure()) {
+                            return fail(`${prop}: cannot render name - ${renderResult.message}`);
+                        }
+                        return fail(`${prop}: renders empty name`);
                     }
                 }
 
@@ -230,7 +234,7 @@ export class ConditionalJson extends BaseConverter<JsonValue> {
                         return succeed(v);
                     });
 
-                    if (result.isFailure() && (this._options.onInvalidProperty === 'error')) {
+                    if (result.isFailure() && (this._options.onInvalidPropertyValue === 'error')) {
                         return fail(result.message);
                     }
                 }

--- a/src/conditionalJson.ts
+++ b/src/conditionalJson.ts
@@ -35,7 +35,7 @@ import {
     isJsonObject,
     isJsonPrimitive,
 } from './common';
-import { JsonConverterOptions, defaultJsonConverterOptions } from './jsonConverter';
+import { JsonConverterOptions, mergeDefaultJsonConverterOptions } from './jsonConverter';
 
 import { JsonMerger } from './jsonMerger';
 import Mustache from 'Mustache';
@@ -58,7 +58,7 @@ export interface ConditionalJsonOptions extends JsonConverterOptions {
  * - onMalformedCondition: 'error'
  */
 export const defaultConditionalJsonOptions: ConditionalJsonOptions = {
-    ...defaultJsonConverterOptions,
+    ...mergeDefaultJsonConverterOptions(),
     onMalformedCondition: 'error',
 };
 

--- a/src/converters.ts
+++ b/src/converters.ts
@@ -22,6 +22,7 @@
 
 import { ConditionalJson } from './conditionalJson';
 import { JsonConverter } from './jsonConverter';
+import { TemplateContext } from './templateContext';
 
 /**
  * Converts the supplied unknown to JSON, rendering any property names
@@ -29,7 +30,7 @@ import { JsonConverter } from './jsonConverter';
  * mustache documentation for details of mustache syntax and view.
  * @param context The mustache view used to render property names and string values
  */
-export function templatedJson(context: unknown): JsonConverter {
+export function templatedJson(context: TemplateContext): JsonConverter {
     return new JsonConverter({ templateContext: context });
 }
 
@@ -57,6 +58,6 @@ export const jsonArray = json.array();
  * conditional flattening based on property names.
  * @param context The mustache view used to render property names and string values
  */
-export function conditionalJson(context: unknown): ConditionalJson {
+export function conditionalJson(context: TemplateContext): ConditionalJson {
     return new ConditionalJson({ templateContext: context });
 }

--- a/src/jsonConverter.ts
+++ b/src/jsonConverter.ts
@@ -111,7 +111,7 @@ export function mergeDefaultJsonConverterOptions(partial?: Partial<JsonConverter
     }
 
     if (options.deriveContext === undefined) {
-        options.useValueTemplates = false;
+        options.useArrayTemplateNames = false;
     }
     return options;
 }
@@ -174,6 +174,8 @@ export abstract class JsonConverterBase extends BaseConverter<JsonValue, Templat
 
         if (arrayResult.isSuccess()) {
             const mergeResult = this._mergeInPlace(target, arrayResult.value);
+            // can only happen with internal error or out of resources
+            // istanbul ignore next
             if (mergeResult.isFailure()) {
                 return fail(`${sourceName}: ${mergeResult.message}`);
             }
@@ -228,8 +230,6 @@ export class JsonConverter extends JsonConverterBase {
     public constructor(options?: Partial<JsonConverterOptions>) {
         super(options);
     }
-
-    public get defaultContext(): TemplateContext|undefined { return this._options.templateContext; }
 
     /**
      * Creates a new converter.

--- a/src/jsonConverter.ts
+++ b/src/jsonConverter.ts
@@ -29,7 +29,7 @@ import {
     succeed,
 } from '@fgv/ts-utils';
 import { JsonArray, JsonObject, JsonValue, isJsonObject, isJsonPrimitive } from './common';
-import { TemplateContext, TemplateContextDeriver, deriveTemplateContext } from './templateContext';
+import { TemplateContext, TemplateContextDeriveFunction, deriveTemplateContext } from './templateContext';
 
 import { ArrayPropertyConverter } from './arrayProperty';
 import { JsonMerger } from './jsonMerger';
@@ -75,7 +75,7 @@ export interface JsonConverterOptions {
      * Method used to derive context for children of an array node during
      * expansion. If undefined then array name expansion is disabled.
      */
-    contextDeriver?: TemplateContextDeriver;
+    deriveContext?: TemplateContextDeriveFunction;
 
     /**
      * If onInvalidPropertyName is 'error' (default) then any property name
@@ -101,7 +101,7 @@ export function mergeDefaultJsonConverterOptions(partial?: Partial<JsonConverter
         useArrayTemplateNames: true,
         onInvalidPropertyName: 'error',
         onInvalidPropertyValue: 'error',
-        contextDeriver: deriveTemplateContext,
+        deriveContext: deriveTemplateContext,
         ... (partial ?? {}),
     };
 
@@ -110,7 +110,7 @@ export function mergeDefaultJsonConverterOptions(partial?: Partial<JsonConverter
         options.useNameTemplates = false;
     }
 
-    if (options.contextDeriver === undefined) {
+    if (options.deriveContext === undefined) {
         options.useValueTemplates = false;
     }
     return options;

--- a/src/templateContext.ts
+++ b/src/templateContext.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2020 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import { Result, succeed } from '@fgv/ts-utils';
+
+export type TemplateContext = Record<string, unknown>;
+export type TemplateContextDeriver = (base: TemplateContext|undefined, ...values: [string, unknown][]) => Result<TemplateContext>;
+
+export function deriveTemplateContext(base: TemplateContext|undefined, ...values: [string, unknown][]): Result<TemplateContext> {
+    const rtrn = (base ? Object.create(base) : {});
+    for (const v of values) {
+        rtrn[v[0]] = v[1];
+    }
+    return succeed(rtrn);
+}

--- a/src/templateContext.ts
+++ b/src/templateContext.ts
@@ -23,7 +23,7 @@
 import { Result, succeed } from '@fgv/ts-utils';
 
 export type TemplateContext = Record<string, unknown>;
-export type TemplateContextDeriver = (base: TemplateContext|undefined, ...values: [string, unknown][]) => Result<TemplateContext>;
+export type TemplateContextDeriveFunction = (base: TemplateContext|undefined, ...values: [string, unknown][]) => Result<TemplateContext>;
 
 export function deriveTemplateContext(base: TemplateContext|undefined, ...values: [string, unknown][]): Result<TemplateContext> {
     const rtrn = (base ? Object.create(base) : {});

--- a/test/unit/arrayProperty.test.ts
+++ b/test/unit/arrayProperty.test.ts
@@ -61,7 +61,7 @@ describe('ArrayPropertyConverter class', () => {
 
         test('fails with detail error if useArrayTemplateNames is true but deriveContext is not defined', () => {
             const opts = mergeDefaultJsonConverterOptions({ useArrayTemplateNames: true });
-            opts.contextDeriver = undefined;
+            opts.deriveContext = undefined;
             expect(ArrayPropertyConverter.create(token, context, converter, opts)).toFailWithDetail(
                 /no context.*function/i,
                 'error',

--- a/test/unit/arrayProperty.test.ts
+++ b/test/unit/arrayProperty.test.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2020 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+
+import * as JsonConverters from '../../src/converters';
+import { ArrayPropertyConverter } from '../../src/arrayProperty';
+import { mergeDefaultJsonConverterOptions } from '../../src';
+
+describe('ArrayPropertyConverter class', () => {
+    const token = '[[prop]]=value1,value2';
+    const context = {};
+    const converter = JsonConverters.json;
+    const options = mergeDefaultJsonConverterOptions({});
+
+    describe('static create', () => {
+        test('succeeds with a parseable value and valid init', () => {
+            expect(ArrayPropertyConverter.create(token, context, converter, options)).toSucceed();
+        });
+
+        test('fails with detail notAnArray if the token is not an array', () => {
+            expect(ArrayPropertyConverter.create('whatever', context, converter, options)).toFailWithDetail(
+                /not an array/i,
+                'notAnArray',
+            );
+        });
+
+        test('fails with detail error if the token is a malformed array', () => {
+            expect(ArrayPropertyConverter.create('[[feh]', context, converter, options)).toFailWithDetail(
+                /malformed array/i,
+                'error',
+            );
+        });
+
+        test('fails with detail disabled if useArrayTemplateNames is false', () => {
+            const opts = mergeDefaultJsonConverterOptions({ useArrayTemplateNames: false });
+            expect(ArrayPropertyConverter.create(token, context, converter, opts)).toFailWithDetail(
+                /disabled/i,
+                'disabled',
+            );
+        });
+
+        test('fails with detail error if useArrayTemplateNames is true but deriveContext is not defined', () => {
+            const opts = mergeDefaultJsonConverterOptions({ useArrayTemplateNames: true });
+            opts.contextDeriver = undefined;
+            expect(ArrayPropertyConverter.create(token, context, converter, opts)).toFailWithDetail(
+                /no context.*function/i,
+                'error',
+            );
+        });
+    });
+});

--- a/test/unit/conditonalJson.test.ts
+++ b/test/unit/conditonalJson.test.ts
@@ -282,7 +282,7 @@ describe('ConditionalJson class', () => {
         });
     });
 
-    describe('with onMalformedCondition ignore', () => {
+    describe('with onInvalidPropertyName ignore', () => {
         const tests = [
             {
                 src: {
@@ -296,7 +296,7 @@ describe('ConditionalJson class', () => {
         test('ignores malformed conditions', () => {
             tests.forEach((t) => {
                 const cjson = new ConditionalJson({
-                    onMalformedCondition: 'ignore',
+                    onInvalidPropertyName: 'ignore',
                     templateContext: t.context,
                 });
                 expect(cjson.convert(t.src)).toSucceedWith(t.src);

--- a/test/unit/conditonalJson.test.ts
+++ b/test/unit/conditonalJson.test.ts
@@ -187,6 +187,28 @@ describe('ConditionalJson class', () => {
                 conditional2: 'templated conditional the second',
             },
         },
+        {
+            description: 'expands an array property',
+            src: {
+                '[[prop]]={{properties}}': {
+                    '{{prop}}Prop': '{{prop}} value',
+                },
+            },
+            context: {
+                properties: ['first', 'second', 'third'],
+            },
+            expected: {
+                first: {
+                    firstProp: 'first value',
+                },
+                second: {
+                    secondProp: 'second value',
+                },
+                third: {
+                    thirdProp: 'third value',
+                },
+            },
+        },
     ];
 
     describe('success cases', () => {
@@ -243,6 +265,15 @@ describe('ConditionalJson class', () => {
             expected: /malformed condition/i,
         },
         {
+            description: 'fails for malformed array',
+            src: {
+                '[[feh': {
+                    weird: 'and invalid',
+                },
+            },
+            expected: /malformed array/i,
+        },
+        {
             description: 'fails if conditional value is non-object',
             src: {
                 '?this=this': 'hello',
@@ -292,8 +323,16 @@ describe('ConditionalJson class', () => {
                 },
                 context: {},
             },
+            {
+                src: {
+                    '[[feh': {
+                        property: 'weird but accepted',
+                    },
+                },
+                context: {},
+            },
         ];
-        test('ignores malformed conditions', () => {
+        test('ignores malformed conditions or arrays', () => {
             tests.forEach((t) => {
                 const cjson = new ConditionalJson({
                     onInvalidPropertyName: 'ignore',

--- a/test/unit/conditonalJson.test.ts
+++ b/test/unit/conditonalJson.test.ts
@@ -209,6 +209,30 @@ describe('ConditionalJson class', () => {
             expected: /cannot convert/i,
         },
         {
+            description: 'fails for malformed template',
+            src: {
+                '{{value}': {
+                    weird: 'and invalid',
+                },
+            },
+            context: {
+                prop: 'this',
+            },
+            expected: /cannot render name/i,
+        },
+        {
+            description: 'fails for name that renders empty',
+            src: {
+                '{{bogus}}': {
+                    weird: 'and invalid',
+                },
+            },
+            context: {
+                prop: 'this',
+            },
+            expected: /renders empty name/i,
+        },
+        {
             description: 'fails for malformed conditional',
             src: {
                 '?this=this=this': {
@@ -265,7 +289,22 @@ describe('ConditionalJson class', () => {
                         property: 'weird but accepted',
                     },
                 },
+                context: {},
             },
+        ];
+        test('ignores malformed conditions', () => {
+            tests.forEach((t) => {
+                const cjson = new ConditionalJson({
+                    onMalformedCondition: 'ignore',
+                    templateContext: t.context,
+                });
+                expect(cjson.convert(t.src)).toSucceedWith(t.src);
+            });
+        });
+    });
+
+    describe('with onInvalidPropertyName ignore', () => {
+        const tests = [
             {
                 src: {
                     '{{prop}=this': {
@@ -276,13 +315,25 @@ describe('ConditionalJson class', () => {
                     prop: 'this',
                 },
             },
+            {
+                src: {
+                    '{{otherProp}}': {
+                        property: 'weird but accepted',
+                    },
+                },
+                context: {
+                    prop: 'this',
+                },
+            },
         ];
-        tests.forEach((t) => {
-            const cjson = new ConditionalJson({
-                onMalformedCondition: 'ignore',
-                templateContext: t.context,
+        test('ignores invalid property names', () => {
+            tests.forEach((t) => {
+                const cjson = new ConditionalJson({
+                    onInvalidPropertyName: 'ignore',
+                    templateContext: t.context,
+                });
+                expect(cjson.convert(t.src)).toSucceedWith(t.src);
             });
-            expect(cjson.convert(t.src)).toSucceedWith(t.src);
         });
     });
 

--- a/test/unit/conditonalJson.test.ts
+++ b/test/unit/conditonalJson.test.ts
@@ -21,11 +21,12 @@
  */
 import '@fgv/ts-utils-jest';
 import { ConditionalJson, JsonObject } from '../../src';
+import { TemplateContext } from '../../src/templateContext';
 
 interface ConditionalJsonSuccessTest {
     description: string;
     src: JsonObject;
-    context?: unknown;
+    context?: TemplateContext;
     expected: JsonObject;
 }
 

--- a/test/unit/jsonConverter.test.ts
+++ b/test/unit/jsonConverter.test.ts
@@ -59,7 +59,7 @@ describe('JsonConverter class', () => {
                 someProperty: 'unchanged property should be {{unchanged}}',
                 '[[index]]=alpha,beta': 'index is {{index}}',
             }, {
-                unchanged: 'runtime value',
+                unchanged: () => 'runtime value',
                 index: 'runtime index',
             })).toSucceedWith({
                 someProperty: 'unchanged property should be runtime value',

--- a/test/unit/jsonConverter.test.ts
+++ b/test/unit/jsonConverter.test.ts
@@ -22,7 +22,6 @@
 
 import '@fgv/ts-utils-jest';
 import { JsonConverter } from '../../src/jsonConverter';
-import { defaultObjectContextCreator } from '../../src/arrayProperty';
 
 describe('JsonConverter class', () => {
     // most functionality tested indirectly via converters module
@@ -37,12 +36,11 @@ describe('JsonConverter class', () => {
     });
 
     describe('with array expansion', () => {
-        const converter = new JsonConverter<Record<string, unknown>>({
+        const converter = new JsonConverter({
             templateContext: {
                 unchanged: 'unchanged value',
                 index: 'original index',
             },
-            contextCreator: defaultObjectContextCreator,
         });
 
         test('expands valid array template names', () => {

--- a/test/unit/jsonConverter.test.ts
+++ b/test/unit/jsonConverter.test.ts
@@ -36,9 +36,67 @@ describe('JsonConverter class', () => {
         });
     });
 
-    describe('with onInvalidProperty of error', () => {
-        test('fails for invalid properties', () => {
-            const converter = new JsonConverter({ onInvalidProperty: 'error' });
+    describe('with onInvalidPropertyName of error', () => {
+        test('fails for invalid property names', () => {
+            const converter = new JsonConverter({
+                templateContext: { value: 'hello' },
+                onInvalidPropertyName: 'error',
+            });
+
+            expect(converter.convert({
+                valid: 'valid name and value',
+                '{{invalid': 'invalid name valid value',
+            })).toFailWith(/cannot render/i);
+        });
+
+        test('fails for empty property names', () => {
+            const converter = new JsonConverter({
+                templateContext: { value: 'hello' },
+                onInvalidPropertyName: 'error',
+            });
+
+            expect(converter.convert({
+                valid: 'valid name and value',
+                '{{invalid}}': 'empty name valid value',
+            })).toFailWith(/renders empty name/i);
+        });
+    });
+
+    describe('with onInvalidPropertyName of ignore', () => {
+        test('silently ignores invalid property names', () => {
+            const converter = new JsonConverter({
+                onInvalidPropertyName: 'ignore',
+                templateContext: { prop: 'value' },
+            });
+
+            expect(converter.convert({
+                valid: 'valid',
+                '{{invalid': 'invalid name, valid value',
+            })).toSucceedWith({
+                valid: 'valid',
+                '{{invalid': 'invalid name, valid value',
+            });
+        });
+
+        test('silently ignores empty property names', () => {
+            const converter = new JsonConverter({
+                onInvalidPropertyName: 'ignore',
+                templateContext: { prop: 'value' },
+            });
+
+            expect(converter.convert({
+                valid: 'valid',
+                '{{invalid}}': 'invalid name, valid value',
+            })).toSucceedWith({
+                valid: 'valid',
+                '{{invalid}}': 'invalid name, valid value',
+            });
+        });
+    });
+
+    describe('with onInvalidPropertyValue of error', () => {
+        test('fails for invalid property values', () => {
+            const converter = new JsonConverter({ onInvalidPropertyValue: 'error' });
             expect(converter.convert({
                 valid: 'valid',
                 invalid: () => 'invalid',
@@ -46,9 +104,9 @@ describe('JsonConverter class', () => {
         });
     });
 
-    describe('with onInvalidProperty of ignore', () => {
+    describe('with onInvalidPropertyValue of ignore', () => {
         test('silently ignores invalid properties', () => {
-            const converter = new JsonConverter({ onInvalidProperty: 'ignore' });
+            const converter = new JsonConverter({ onInvalidPropertyValue: 'ignore' });
             expect(converter.convert({
                 valid: 'valid',
                 invalid: () => 'invalid',

--- a/test/unit/jsonConverter.test.ts
+++ b/test/unit/jsonConverter.test.ts
@@ -21,9 +21,49 @@
  */
 
 import '@fgv/ts-utils-jest';
-import { JsonConverter } from '../../src/jsonConverter';
+import { JsonConverter, JsonConverterOptions, mergeDefaultJsonConverterOptions } from '../../src/jsonConverter';
 
 describe('JsonConverter class', () => {
+    describe('mergeDefaultJsonConverterOptions function', () => {
+        test('enables template names and values if a context is supplied', () => {
+            const expected: JsonConverterOptions = {
+                useValueTemplates: true,
+                useNameTemplates: true,
+                useArrayTemplateNames: true,
+                templateContext: {},
+                deriveContext: expect.any(Function),
+                onInvalidPropertyName: 'error',
+                onInvalidPropertyValue: 'error',
+            };
+            expect(mergeDefaultJsonConverterOptions({ templateContext: {} })).toEqual(expected);
+        });
+
+        test('disables template names and values if no context is supplied', () => {
+            const expected: JsonConverterOptions = {
+                useValueTemplates: false,
+                useNameTemplates: false,
+                useArrayTemplateNames: true,
+                deriveContext: expect.any(Function),
+                onInvalidPropertyName: 'error',
+                onInvalidPropertyValue: 'error',
+            };
+            expect(mergeDefaultJsonConverterOptions()).toEqual(expected);
+        });
+
+        test('disables array template names if no context derive function is present', () => {
+            const expected: JsonConverterOptions = {
+                useValueTemplates: true,
+                useNameTemplates: true,
+                useArrayTemplateNames: false,
+                templateContext: {},
+                deriveContext: undefined,
+                onInvalidPropertyName: 'error',
+                onInvalidPropertyValue: 'error',
+            };
+            expect(mergeDefaultJsonConverterOptions({ templateContext: {}, deriveContext: undefined })).toEqual(expected);
+        });
+    });
+
     // most functionality tested indirectly via converters module
     describe('create method', () => {
         test('succeeds with no options', () => {

--- a/test/unit/templateContext.test.ts
+++ b/test/unit/templateContext.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020 Erik Fortune
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import '@fgv/ts-utils-jest';
+import { deriveTemplateContext } from '../../src/templateContext';
+
+describe('templateContext module', () => {
+    describe('deriveTemplateContext function', () => {
+        test('adds properties', () => {
+            expect(deriveTemplateContext({
+                prop1: 'value 1',
+                prop2: 'value 2',
+            }, ['prop1', 'override 1'], ['prop3', 'new value 3'])).toSucceedAndSatisfy((ctx: Record<string, unknown>) => {
+                expect(ctx.prop1).toEqual('override 1');
+                expect(ctx.prop2).toEqual('value 2');
+                expect(ctx.prop3).toEqual('new value 3');
+            });
+        });
+
+        test('preserves and adds functions', () => {
+            expect(deriveTemplateContext({
+                func1: () => 'value 1',
+                func2: () => 'value 2',
+            },
+            ['func2', () => 'override 2'],
+            ['func3', () => 'new value 3'],
+            )).toSucceedAndSatisfy((ctx: Record<string, unknown>) => {
+                expect(typeof ctx.func1).toEqual('function');
+                expect(typeof ctx.func2).toEqual('function');
+                expect(typeof ctx.func3).toEqual('function');
+                if (typeof ctx.func1 === 'function') {
+                    expect(ctx.func1()).toEqual('value 1');
+                }
+                if (typeof ctx.func2 === 'function') {
+                    expect(ctx.func2()).toEqual('override 2');
+                }
+                if (typeof ctx.func3 === 'function') {
+                    expect(ctx.func3()).toEqual('new value 3');
+                }
+            });
+        });
+
+        test('populates an empty object if base context is undefined', () => {
+            expect(deriveTemplateContext(undefined, ['prop1', 123])).toSucceedWith({
+                prop1: 123,
+            });
+        });
+    });
+});


### PR DESCRIPTION
Adds a syntax to both templated and conditional JSON which makes it possible to generate multiple templated properties for a property if the context yields an array.   See the README fro an example.

fixes #7